### PR TITLE
Attempting to fix issue with PRs not running github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Unity Test Runner
 on:
   workflow_dispatch:
   push:
-  pull_request:
+  pull_request_target:
 
 jobs:
   test:


### PR DESCRIPTION
Changed the github action event trigger from `on: pull_request` to  `on: pull_request_target` I think this will allow PRs to access the Unity licensing information, but I am not positive. See github documentation [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target)